### PR TITLE
substitute env vars in uri setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+build:
+	go clean
+	go build
+	go test -v . ./atlas
+
+linux:
+	env GOOS=linux GOARCH=amd64 go build

--- a/atlas/atlas.go
+++ b/atlas/atlas.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"regexp"
 	"strings"
 
@@ -250,12 +251,24 @@ func filterNot(metrics []plugin.MetricType, re *regexp.Regexp) []plugin.MetricTy
 	}
 }
 
+// Return environment variables as a map.
+func getenv() map[string]string {
+	envVars := map[string]string{}
+	for _, e := range os.Environ() {
+		pair := strings.Split(e, "=")
+		if len(pair) == 2 {
+			envVars[pair[0]] = pair[1]
+		}
+	}
+	return envVars
+}
+
 func (f *atlasPublisher) Publish(contentType string, content []byte, config map[string]ctypes.ConfigValue) error {
 	logger := log.New()
 	logger.Println("Publishing started")
 	var metrics []plugin.MetricType
 
-	uri := config["uri"].(ctypes.ConfigValueStr).Value
+	uri := substitute(config["uri"].(ctypes.ConfigValueStr).Value, getenv())
 	exclude := getExclude(logger, config)
 
 	logger.Printf("URI %v", uri)


### PR DESCRIPTION
Allow environment variables to be used as part of the
configured uri. This make it easier in some case to have
a simple a config that adjusts automatically to send to
the right place based on where it is running.
